### PR TITLE
Leaving Wintergrasp teleports in Icecrown, North of Wintergrasp!

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -402,8 +402,8 @@ void Battlefield::AskToLeaveQueue(Player* player)
 // Called in WorldSession::HandleHearthAndResurrect
 void Battlefield::PlayerAskToLeave(Player* player)
 {
-    // Player leaving Wintergrasp, trigger Hearthstone spell.
-    player->CastSpell(player, 8690, true);
+    // Player leaving Wintergrasp, teleports to Icecrown just north of Wintergrasp.
+    player->TeleportTo(571, 5728.117188f, 2714.345947f, 697.732971f, 0.0000f);
 }
 
 // Called in WorldSession::HandleBfEntryInviteResponse

--- a/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
+++ b/src/server/scripts/EasternKingdoms/BlackrockMountain/MoltenCore/boss_ragnaros.cpp
@@ -78,7 +78,6 @@ enum Events
     EVENT_HAND_OF_RAGNAROS,
     EVENT_MIGHT_OF_RAGNAROS,
     EVENT_LAVA_BURST,
-    EVENT_MAGMA_BLAST_MELEE_CHECK,
     EVENT_MAGMA_BLAST,
     EVENT_SUBMERGE,
     EVENT_LAVA_BURST_TRIGGER,
@@ -122,6 +121,7 @@ public:
         boss_ragnarosAI(Creature* creature) : BossAI(creature, DATA_RAGNAROS),
             _isIntroDone(false),
             _hasYelledMagmaBurst(false),
+            _processingMagmaBurst(false),
             _hasSubmergedOnce(false),
             _isKnockbackEmoteAllowed(true)
         {
@@ -143,6 +143,7 @@ public:
             }
 
             _hasYelledMagmaBurst = false;
+            _processingMagmaBurst = false;
             _hasSubmergedOnce = false;
             _isKnockbackEmoteAllowed = true;
             me->SetUInt32Value(UNIT_NPC_EMOTESTATE, 0);
@@ -231,6 +232,28 @@ public:
             }
         }
 
+        void EnterEvadeMode() override
+        {
+            if (!me->getThreatMgr().getThreatList().empty())
+            {
+                if (!_processingMagmaBurst)
+                {
+                    // Boss try to evade, but still got some targets on threat list - it means that none of these targets are in melee range - cast magma blast
+                    _processingMagmaBurst = true;
+                    events.ScheduleEvent(EVENT_MAGMA_BLAST, 4000, PHASE_EMERGED, PHASE_EMERGED);
+                }
+            }
+            else
+            {
+                BossAI::EnterEvadeMode();
+            }
+        }
+
+        bool CanAIAttack(Unit const* victim) const override
+        {
+            return me->IsWithinMeleeRange(victim);
+        }
+
         void UpdateAI(uint32 diff) override
         {
             if (!extraEvents.Empty())
@@ -297,7 +320,10 @@ public:
 
             if (!UpdateVictim())
             {
-                return;
+                if (!_processingMagmaBurst)
+                {
+                    return;
+                }
             }
 
             events.Update(diff);
@@ -340,38 +366,10 @@ public:
                         DoCastAOE(SPELL_LAVA_BURST);
                         break;
                     }
-                    case EVENT_MAGMA_BLAST_MELEE_CHECK:
-                    {
-                        if (Unit* target = ObjectAccessor::GetUnit(*me, me->GetTarget()))
-                        {
-                            if (!target->IsAlive())
-                            {
-                                me->SetTarget(ObjectGuid::Empty);
-                            }
-                        }
-
-                        if (!IsVictimWithinMeleeRange())
-                        {
-                            if (Unit* target = SelectTarget(SelectTargetMethod::MaxThreat, 0, [&](Unit* u) { return u && u->IsPlayer() && me->IsWithinMeleeRange(u); }))
-                            {
-                                me->AttackerStateUpdate(target);
-                                me->SetTarget(target->GetGUID());
-                                events.RepeatEvent(500);
-                            }
-                            else
-                            {
-                                events.ScheduleEvent(EVENT_MAGMA_BLAST, 4000, PHASE_EMERGED, PHASE_EMERGED);
-                            }
-                        }
-                        else
-                        {
-                            _hasYelledMagmaBurst = false;
-                            events.RepeatEvent(500);
-                        }
-                        break;
-                    }
                     case EVENT_MAGMA_BLAST:
                     {
+                        _processingMagmaBurst = false;
+
                         if (!IsVictimWithinMeleeRange())
                         {
                             DoCastRandomTarget(SPELL_MAGMA_BLAST);
@@ -383,7 +381,6 @@ public:
                             }
                         }
 
-                        events.RescheduleEvent(EVENT_MAGMA_BLAST_MELEE_CHECK, 500, PHASE_EMERGED, PHASE_EMERGED);
                         break;
                     }
                     case EVENT_MIGHT_OF_RAGNAROS:
@@ -444,6 +441,7 @@ public:
         EventMap extraEvents;
         bool _isIntroDone;
         bool _hasYelledMagmaBurst;
+        bool _processingMagmaBurst;
         bool _hasSubmergedOnce;
         bool _isKnockbackEmoteAllowed;  // Prevents possible text overlap
 
@@ -480,7 +478,6 @@ public:
             events.RescheduleEvent(EVENT_WRATH_OF_RAGNAROS, 30000, PHASE_EMERGED, PHASE_EMERGED);
             events.RescheduleEvent(EVENT_HAND_OF_RAGNAROS, 25000, PHASE_EMERGED, PHASE_EMERGED);
             events.RescheduleEvent(EVENT_LAVA_BURST, 10000, PHASE_EMERGED, PHASE_EMERGED);
-            events.RescheduleEvent(EVENT_MAGMA_BLAST_MELEE_CHECK, 10000, PHASE_EMERGED, PHASE_EMERGED);
             events.RescheduleEvent(EVENT_SUBMERGE, 180000, PHASE_EMERGED, PHASE_EMERGED);
             events.RescheduleEvent(EVENT_MIGHT_OF_RAGNAROS, 11000, PHASE_EMERGED, PHASE_EMERGED);
         }


### PR DESCRIPTION

## Changes Proposed:
-  Leaving Wintergrasp by clicking on the icon near the map, it teleports you in Icecrown, North of Wintergrasp instead of triggering Hearthstone spell, it is very good because you don't have to waste Hearthstone cooldown! I've tested by myself and it works! You can also give your opinion about this change i've made.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes 

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Yes, i tested on my server and it works very well, no errors!
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go in Wintergrasp, right click on the Icon near the map, Leave Wintergrasp, it will teleport you in Icecrown, North of Wintergrasp, it won't trigger the Hearthstone spell and you won't have any cooldown on it!
2.
3.

## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

- [ ]
- [ ]

If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
