### PR TITLE
WIntergrasp Teleports you in Icecrown, North of Wintergrasp

### DIFF
--- a/src/server/game/Battlefield/Battlefield.cpp
+++ b/src/server/game/Battlefield/Battlefield.cpp
@@ -403,7 +403,7 @@ void Battlefield::AskToLeaveQueue(Player* player)
 void Battlefield::PlayerAskToLeave(Player* player)
 {
     // Player leaving Wintergrasp, teleports to Icecrown just north of Wintergrasp.
-    player->TeleportTo(5711, 5728.117188f, 2714.345947f, 697.732971f, 0.0000f);
+    player->TeleportTo(571, 5728.117188f, 2714.345947f, 697.732971f, 0.0000f);
 }
 
 // Called in WorldSession::HandleBfEntryInviteResponse


### PR DESCRIPTION
## Changes Proposed:
-  Leaving Wintergrasp by clicking on the icon near the map, it teleports you in Icecrown, North of Wintergrasp instead of triggering Hearthstone spell, it is very good because you don't have to waste Hearthstone cooldown! I've tested by myself and it works! You can also give your opinion about this change i've made.
-  

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->


## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- It worked on my server, no errors!
- 


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Go in Wintergrasp, right click on the Icon near the map, Leave Wintergrasp, it will teleport you in Icecrown, North of Wintergrasp, it won't trigger the Hearthstone spell and you won't have any cooldown on it!


## Known Issues and TODO List:
<!-- Is there anything else left to do after this PR? -->

If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
